### PR TITLE
Switch to version 2 of the AWS SDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,3 +17,11 @@ libraryDependencies ++= Seq(
 scalacOptions := Seq("-unchecked", "-deprecation")
 
 assemblyJarName in assembly := "amiup.jar"
+
+assemblyMergeStrategy in assembly := {
+  case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
+  case x if x.endsWith("module-info.class") => MergeStrategy.discard
+  case y =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(y)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "2.13.4"
 
 // Change this to another test framework if you prefer
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-cloudformation" % "1.11.915",
+  "software.amazon.awssdk" % "cloudformation" % "2.15.47",
   "com.github.scopt" %% "scopt" % "4.0.0",
   "org.typelevel" %% "cats-core" % "2.3.0",
   "ch.qos.logback" %  "logback-classic" % "1.2.3",

--- a/src/main/scala/com/gu/ami/amiup/UI.scala
+++ b/src/main/scala/com/gu/ami/amiup/UI.scala
@@ -1,6 +1,6 @@
 package com.gu.ami.amiup
 
-import com.amazonaws.services.cloudformation.model.Stack
+import software.amazon.awssdk.services.cloudformation.model.Stack
 import com.typesafe.scalalogging.LazyLogging
 
 
@@ -18,7 +18,7 @@ object UI extends LazyLogging {
   def confirmStacks(stacks: Seq[Stack]): Either[String, Seq[Stack]] = {
     println(s"Found ${stacks.size} stacks".colour(Console.GREEN))
     stacks.foreach { stack =>
-      println(stack.getStackName)
+      println(stack.stackName)
     }
     print("Update these stacks? [y/N]")
     val confirmation = scala.io.StdIn.readLine()
@@ -34,16 +34,16 @@ object UI extends LazyLogging {
     progress.foreach {
       case StackProgress(stack, _, _, true) =>
         // stack update has failed
-        println(s"${stack.getStackName}: ${stack.getStackStatus}".colour(Console.RED))
+        println(s"${stack.stackName}: ${stack.stackStatus}".colour(Console.RED))
       case StackProgress(stack, true, true, _) =>
-        println(s"${stack.getStackName}: ${stack.getStackStatus}".colour(Console.GREEN))
+        println(s"${stack.stackName}: ${stack.stackStatus}".colour(Console.GREEN))
       case StackProgress(stack, true, false, _) =>
-        println(s"${stack.getStackName}: ${stack.getStackStatus}".colour(Console.CYAN))
+        println(s"${stack.stackName}: ${stack.stackStatus}".colour(Console.CYAN))
       case StackProgress(stack, false, false, _) =>
-        println(s"${stack.getStackName}: Starting...".colour(Console.BLUE))
+        println(s"${stack.stackName}: Starting...".colour(Console.BLUE))
       case StackProgress(stack, false, true, _) =>
-        logger.error(s"stack ${stack.getStackName} in invalid state, finished but not started")
-        println(s"${stack.getStackName}: ${stack.getStackStatus}".colour(Console.CYAN))
+        logger.error(s"stack ${stack.stackName} in invalid state, finished but not started")
+        println(s"${stack.stackName}: ${stack.stackStatus}".colour(Console.CYAN))
     }
     println("-----------------------".colour(Console.RESET))
   }

--- a/src/main/scala/com/gu/ami/amiup/aws/UpdateCloudFormation.scala
+++ b/src/main/scala/com/gu/ami/amiup/aws/UpdateCloudFormation.scala
@@ -1,12 +1,12 @@
 package com.gu.ami.amiup.aws
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormationAsyncClient
-import com.amazonaws.services.cloudformation.model._
 import com.typesafe.scalalogging.LazyLogging
+import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient
+import software.amazon.awssdk.services.cloudformation.model._
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
 
 
 object UpdateCloudFormation extends LazyLogging {
@@ -15,63 +15,65 @@ object UpdateCloudFormation extends LazyLogging {
     StackStatus.UPDATE_ROLLBACK_COMPLETE
   )
 
-  def findStacks(existingAmiOrStacks: Either[String, Seq[String]], parameterName: String, client: AmazonCloudFormationAsyncClient): Future[Seq[Stack]] = {
+  def findStacks(existingAmiOrStacks: Either[String, Seq[String]], parameterName: String, client: CloudFormationAsyncClient): Future[Seq[Stack]] = {
     for {
-      describeStacksResult <- AWS.describeStacks(client)
+      describeStacksResponse <- AWS.describeStacks(client)
     } yield {
-      val allStacks = describeStacksResult.getStacks.asScala.toSeq
+      val allStacks = describeStacksResponse.stacks.asScala.toSeq
       logger.info(s"Found ${allStacks.size} stacks")
-      logger.debug(s"stacks: ${allStacks.map(_.getStackName).mkString(", ")}")
+      logger.debug(s"stacks: ${allStacks.map(_.stackName).mkString(", ")}")
       val matchingStacks = existingAmiOrStacks match {
         case Left(existingAmi) =>
           allStacks.filter(filterStack(existingAmi, parameterName))
         case Right(specifiedStacks) =>
-          allStacks.filter(stack => specifiedStacks.contains(stack.getStackId))
+          allStacks.filter(stack => specifiedStacks.contains(stack.stackId))
       }
       logger.info(s"Using ${matchingStacks.size} stacks")
-      logger.debug(s"Matching stacks: ${matchingStacks.map(_.getStackName).mkString(", ")}")
+      logger.debug(s"Matching stacks: ${matchingStacks.map(_.stackName).mkString(", ")}")
       matchingStacks
     }
   }
 
   def validateStacks(parameterName: String, stacks: Seq[Stack]): Either[String, Seq[Stack]] = {
     val stacksWithoutAmiParameter = stacks.filterNot { stack =>
-      stack.getParameters.asScala.exists(_.getParameterKey == parameterName)
+      stack.parameters.asScala.exists(_.parameterKey == parameterName)
     }
 
     if (stacks.isEmpty) Left("No stacks found")
     else if (stacksWithoutAmiParameter.isEmpty) Right(stacks)
-    else Left(s"The following stacks do not have a `$parameterName` parameter: ${stacksWithoutAmiParameter.map(_.getStackName).mkString(",")}")
+    else Left(s"The following stacks do not have a `$parameterName` parameter: ${stacksWithoutAmiParameter.map(_.stackName).mkString(",")}")
   }
 
-  def updateStacks(stacks: Seq[Stack], newAmi: String, parameterName: String, client: AmazonCloudFormationAsyncClient): Future[Map[Stack, UpdateStackResult]] = {
+  def updateStacks(stacks: Seq[Stack], newAmi: String, parameterName: String, client: CloudFormationAsyncClient): Future[Map[Stack, UpdateStackResponse]] = {
     Future.traverse(stacks)(updateStack(newAmi, parameterName, client)).map(_.toMap)
   }
 
-  def updateStack(newAmi: String, parameterName: String, client: AmazonCloudFormationAsyncClient)(stack: Stack): Future[(Stack, UpdateStackResult)] = {
-    val updateStackRequest = new UpdateStackRequest()
-      .withStackName(stack.getStackName)
-      .withUsePreviousTemplate(true)
-      .withCapabilities(Capability.CAPABILITY_IAM)
-      .withParameters(stack.getParameters.asScala.map {
-        case parameter if parameter.getParameterKey == parameterName =>
-          new Parameter()
-            .withParameterKey(parameterName)
-            .withParameterValue(newAmi)
+  def updateStack(newAmi: String, parameterName: String, client: CloudFormationAsyncClient)(stack: Stack): Future[(Stack, UpdateStackResponse)] = {
+    val updateStackRequest = UpdateStackRequest.builder()
+      .stackName(stack.stackName)
+      .usePreviousTemplate(true)
+      .capabilities(Capability.CAPABILITY_IAM)
+      .parameters(stack.parameters.asScala.map {
+        case parameter if parameter.parameterKey == parameterName =>
+          Parameter.builder()
+            .parameterKey(parameterName)
+            .parameterValue(newAmi)
+            .build()
         case parameter =>
           parameter
       }.asJava)
+      .build()
 
     AWS.updateStack(updateStackRequest, client).map(stack -> _)
   }
 
   private[amiup] def filterStack(sourceAmi: String, parameterName: String)(stack: Stack): Boolean = {
-    val isIncluded = allowedStatuses.contains(StackStatus.fromValue(stack.getStackStatus)) && {
-      stack.getParameters.asScala
-        .find(_.getParameterKey == parameterName)
-        .exists(_.getParameterValue == sourceAmi)
+    val isIncluded = allowedStatuses.contains(stack.stackStatus) && {
+      stack.parameters.asScala
+        .find(_.parameterKey == parameterName)
+        .exists(_.parameterValue == sourceAmi)
     }
-    logger.debug(s"Stack ${stack.getStackName} ${if(isIncluded) "included" else "excluded"}")
+    logger.debug(s"Stack ${stack.stackName} ${if(isIncluded) "included" else "excluded"}")
     isIncluded
   }
 }

--- a/src/main/scala/com/gu/ami/amiup/models.scala
+++ b/src/main/scala/com/gu/ami/amiup/models.scala
@@ -1,7 +1,7 @@
 package com.gu.ami.amiup
 
-import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.cloudformation.model.Stack
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cloudformation.model.Stack
 
 
 case class AMI(amiId: String)
@@ -12,7 +12,7 @@ case class Arguments(
   parameterName: String = "AMI",
   existingAmi: Option[String] = None,
   stackIds: Option[Seq[String]] = None,
-  region: Region = Region.getRegion(Regions.EU_WEST_1)
+  region: Region = Region.EU_WEST_1
 )
 object Arguments {
   def empty() = Arguments("", "")

--- a/src/test/scala/com/gu/ami/amiup/UpdateCloudFormationTest.scala
+++ b/src/test/scala/com/gu/ami/amiup/UpdateCloudFormationTest.scala
@@ -1,8 +1,8 @@
 package com.gu.ami.amiup
 
-import com.amazonaws.services.cloudformation.model.{Parameter, Stack, StackStatus}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.cloudformation.model.{Parameter, Stack, StackStatus}
 
 
 class UpdateCloudFormationTest extends AnyFreeSpec with Matchers {
@@ -13,8 +13,7 @@ class UpdateCloudFormationTest extends AnyFreeSpec with Matchers {
     val parameterName = "AMI"
 
     "filters out a stack with an invalid status" in {
-      val stack = new Stack()
-        .withStackStatus(StackStatus.CREATE_FAILED)
+      val stack = Stack.builder().stackStatus(StackStatus.CREATE_FAILED).build()
       filterStack(sourceAmi, parameterName)(stack) shouldEqual false
     }
 
@@ -22,39 +21,34 @@ class UpdateCloudFormationTest extends AnyFreeSpec with Matchers {
       val status = StackStatus.CREATE_COMPLETE
 
       "filters out a stack with no parameters" in {
-        val stack = new Stack()
-          .withStackStatus(status)
-          .withParameters()
+        val stack = Stack.builder().stackStatus(status).build()
         filterStack(sourceAmi, parameterName)(stack) shouldEqual false
       }
 
       "filters out a stack without a matching parameter name" in {
-        val parameter = new Parameter()
-          .withParameterKey("foo")
-          .withParameterValue("bar")
-        val stack = new Stack()
-          .withStackStatus(status)
-          .withParameters(parameter)
+        val parameter = Parameter.builder()
+          .parameterKey("foo")
+          .parameterValue("bar")
+          .build()
+        val stack = Stack.builder().stackStatus(status).parameters(parameter).build()
         filterStack(sourceAmi, parameterName)(stack) shouldEqual false
       }
 
       "filters out a stack that has a matching parameter name with a different value" in {
-        val parameter = new Parameter()
-          .withParameterKey(parameterName)
-          .withParameterValue("different-value")
-        val stack = new Stack()
-          .withStackStatus(status)
-          .withParameters(parameter)
+        val parameter = Parameter.builder()
+          .parameterKey(parameterName)
+          .parameterValue("different-value")
+          .build()
+        val stack = Stack.builder().stackStatus(status).parameters(parameter).build()
         filterStack(sourceAmi, parameterName)(stack) shouldEqual false
       }
 
       "includes a stack with a matching parameter name/value" in {
-        val matchingParameter = new Parameter()
-          .withParameterKey(parameterName)
-          .withParameterValue(sourceAmi)
-        val stack = new Stack()
-          .withStackStatus(status)
-          .withParameters(matchingParameter)
+        val matchingParameter = Parameter.builder()
+          .parameterKey(parameterName)
+          .parameterValue(sourceAmi)
+          .build()
+        val stack = Stack.builder().stackStatus(status).parameters(matchingParameter).build()
         filterStack(sourceAmi, parameterName)(stack) shouldEqual true
       }
     }

--- a/src/test/scala/com/gu/ami/amiup/aws/PollDescribeStackStatusTest.scala
+++ b/src/test/scala/com/gu/ami/amiup/aws/PollDescribeStackStatusTest.scala
@@ -1,69 +1,62 @@
 package com.gu.ami.amiup.aws
 
-import com.amazonaws.services.cloudformation.model.{Stack, StackStatus}
 import com.gu.ami.amiup.StackProgress
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.cloudformation.model.{Stack, StackStatus}
 
 class PollDescribeStackStatusTest extends AnyFreeSpec with Matchers {
   import PollDescribeStackStatus._
 
+  private def createStack(status: StackStatus): Stack = {
+    Stack.builder()
+      .stackName("test-stack")
+      .stackId("test-stack")
+      .stackStatus(status)
+      .build()
+  }
+
   "updateProgress" - {
     "starts a stack that is neither started nor finished, if its status says it has started" in {
-      val stack = new Stack()
-        .withStackName("test-stack")
-        .withStackId("test-stack")
-        .withStackStatus(StackStatus.CREATE_COMPLETE)
+      val stack = createStack(StackStatus.CREATE_COMPLETE)
       val prevProgress = StackProgress(stack, started = false, finished = false, failed = false)
-      val currentStatus = stack.clone().withStackStatus(StackStatus.UPDATE_IN_PROGRESS)
+      val currentStatus = createStack(StackStatus.UPDATE_IN_PROGRESS)
 
       val progress = updateProgress(Seq(prevProgress), Seq(currentStatus))
       progress.head.started shouldEqual true
     }
 
     "does not start a stack if its status hasn't begun" in {
-      val stack = new Stack()
-        .withStackName("test-stack")
-        .withStackId("test-stack")
-        .withStackStatus(StackStatus.CREATE_COMPLETE)
+      val stack = createStack(StackStatus.CREATE_COMPLETE)
       val prevProgress = StackProgress(stack, started = false, finished = false, failed = false)
-      val currentStatus = stack.clone().withStackStatus(StackStatus.CREATE_COMPLETE)
+      val currentStatus = createStack(StackStatus.CREATE_COMPLETE)
 
       val progress = updateProgress(Seq(prevProgress), Seq(currentStatus))
       progress.head.started shouldEqual false
     }
 
     "finishes a stack that has already started" in {
-      val stack = new Stack()
-        .withStackName("test-stack")
-        .withStackId("test-stack")
-        .withStackStatus(StackStatus.UPDATE_IN_PROGRESS)
+      val stack = createStack(StackStatus.UPDATE_IN_PROGRESS)
       val prevProgress = StackProgress(stack, started = true, finished = false, failed = false)
-      val currentStatus = stack.clone().withStackStatus(StackStatus.UPDATE_COMPLETE)
+      val currentStatus = createStack(StackStatus.UPDATE_COMPLETE)
 
       val progress = updateProgress(Seq(prevProgress), Seq(currentStatus))
       progress.head.finished shouldEqual true
     }
 
     "fails a stack that has started and is in a failure state" in {
-      val stack = new Stack()
-        .withStackName("test-stack")
-        .withStackId("test-stack")
-        .withStackStatus(StackStatus.UPDATE_IN_PROGRESS)
+      val stack = createStack(StackStatus.UPDATE_IN_PROGRESS)
       val prevProgress = StackProgress(stack, started = true, finished = false, failed = false)
-      val currentStatus = stack.clone().withStackStatus(StackStatus.UPDATE_ROLLBACK_IN_PROGRESS)
+      val currentStatus = createStack(StackStatus.UPDATE_ROLLBACK_IN_PROGRESS)
 
       val progress = updateProgress(Seq(prevProgress), Seq(currentStatus))
       progress.head.failed shouldEqual true
     }
 
     "does not fail a stack that in a failure state if it has not started (must be left over from the last update)" in {
-      val stack = new Stack()
-        .withStackName("test-stack")
-        .withStackId("test-stack")
-        .withStackStatus(StackStatus.UPDATE_ROLLBACK_COMPLETE)
+      val stack = createStack(StackStatus.UPDATE_ROLLBACK_COMPLETE)
       val prevProgress = StackProgress(stack, started = false, finished = false, failed = false)
-      val currentStatus = stack.clone().withStackStatus(StackStatus.UPDATE_ROLLBACK_COMPLETE)
+      val currentStatus = createStack(StackStatus.UPDATE_ROLLBACK_COMPLETE)
 
       val progress = updateProgress(Seq(prevProgress), Seq(currentStatus))
       progress.head.failed shouldEqual false
@@ -72,15 +65,15 @@ class PollDescribeStackStatusTest extends AnyFreeSpec with Matchers {
 
   "complete" - {
     "is true when all stacks are started and finished" in {
-      val finished1 = StackProgress(new Stack(), started = true, finished = true, failed = false)
-      val finished2 = StackProgress(new Stack(), started = true, finished = true, failed = false)
+      val finished1 = StackProgress(Stack.builder().build(), started = true, finished = true, failed = false)
+      val finished2 = StackProgress(Stack.builder().build(), started = true, finished = true, failed = false)
 
       complete(Seq(finished1, finished2)) shouldEqual true
     }
 
     "is false if there is a stack that is not finished" in {
-      val finished = StackProgress(new Stack(), started = true, finished = true, failed = false)
-      val unfinished = StackProgress(new Stack(), started = true, finished = false, failed = false)
+      val finished = StackProgress(Stack.builder().build(), started = true, finished = true, failed = false)
+      val unfinished = StackProgress(Stack.builder().build(), started = true, finished = false, failed = false)
 
       complete(Seq(finished, unfinished)) shouldEqual false
     }


### PR DESCRIPTION
## What does this change?

#### 👉  Switch to version 2 of the AWS SDK

The majority of the changes here are relate to the change in the SDK.
Thankfully, AMIup only uses the AWS Cloudformation library.

#### 👉  Add assembly merge strategy to fix deduplication

Running `./sbt assembly` was not successful after the version change, due to two errors encountered during merge:

-  deduplicate: different file contents in io.netty.versions.properties (netty)
- deduplicate: different file contents in module-info.class (jackson)

The [documentation for sbt-assembly](https://github.com/sbt/sbt-assembly#merge-strategy) recommends specifying a merge strategy to resolve deduplication issues. The contents of the strategy introduced have been bases on approaches taken by other Guardian projects.

## How to test

1) Run the project directly with sbt
2) Attempt to update an AMI

or...

1) Build the jar using the assembly method 
2) Use the jar to attempt to update an AMI

Both methods have been tested on this branch and work as expected ✅ ✅ 

## How can we measure success?

Valid jars for AMIup can still be assembled and used to perform AMI updates.
We can expand the functionality of AMIup using v2 of the AWS SDK
