### PR TITLE
Add Yolo mode, fix issue affecting noecho parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src_managed/
 project/boot/
 .history
 .cache
+.bsp/
 
 
 ### Scala ###

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ argument. Once it has kicked off the CloudFormation update it will
 poll stacks until the update completes, letting you know the current
 status of each stack.
 
+### YOLO Mode
+
+The `yolo` mode of `amiup` will start an instance refresh on the
+autoscaling group once the CloudFormation template has been updated.
+Instances will be replaced with a rolling update; running instances
+will be terminated before new ones launch.
+
+Rolling updates can fail due to failed health checks or if instances
+are on standby or are protected from scale in. If the update process
+fails, any instances already replaced will not be rolled back to their
+previous configuration.
+
 ## Development / alternate usage
 
 You can also check out the project and run it directly using

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ are on standby or are protected from scale in. If the update process
 fails, any instances already replaced will not be rolled back to their
 previous configuration.
 
+To run `amiup` in `yolo` mode the ASG name, stack name and new AMI are
+required arguments:
+
+```bash
+java -jar amiup.jar yolo --asg <asg name> --stack <stack name> --new ami-567890 --profile <AWS profile> [--region <aws region name>]
+```
+
 ## Development / alternate usage
 
 You can also check out the project and run it directly using

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ assemblyJarName in assembly := "amiup.jar"
 assemblyMergeStrategy in assembly := {
   case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
   case x if x.endsWith("module-info.class") => MergeStrategy.discard
+  case PathList(ps@_*) if Set("customization.config" , "examples-1.json" , "paginators-1.json", "service-2.json" , "waiters-2.json").contains(ps.last) =>
+    MergeStrategy.discard
   case y =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(y)

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.13.4"
 // Change this to another test framework if you prefer
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "cloudformation" % "2.15.47",
+  "software.amazon.awssdk" % "autoscaling" % "2.15.47",
   "com.github.scopt" %% "scopt" % "4.0.0",
   "org.typelevel" %% "cats-core" % "2.3.0",
   "ch.qos.logback" %  "logback-classic" % "1.2.3",

--- a/src/main/scala/com/gu/ami/amiup/AmiUp.scala
+++ b/src/main/scala/com/gu/ami/amiup/AmiUp.scala
@@ -59,7 +59,7 @@ object AmiUp {
           )
           // begin rolling update of instances in the ASG
           response <- EitherT.right(AutoScaling.startInstanceRefresh(autoScalingClient, matchingAsg))
-          _ <- AutoScaling.pollUntilComplete(autoScalingClient, matchingAsg, response.instanceRefreshId)
+          _ <- AutoScaling.pollRefreshProgress(autoScalingClient, matchingAsg, response.instanceRefreshId)(UI.displayRefreshProgress)
         } yield Right(())
       case _ =>
         EitherT[Future, String, Unit](Future.successful(Right(())))

--- a/src/main/scala/com/gu/ami/amiup/AmiUp.scala
+++ b/src/main/scala/com/gu/ami/amiup/AmiUp.scala
@@ -2,7 +2,7 @@ package com.gu.ami.amiup
 
 import cats.data.EitherT
 import cats.instances.future._
-import com.gu.ami.amiup.aws.{AWS, PollDescribeStackStatus, UpdateCloudFormation}
+import com.gu.ami.amiup.aws.{AWS, AutoScaling, PollDescribeStackStatus, UpdateCloudFormation}
 import com.gu.ami.amiup.util.RichFuture._
 import scopt.OptionParser
 import software.amazon.awssdk.regions.Region

--- a/src/main/scala/com/gu/ami/amiup/AmiUp.scala
+++ b/src/main/scala/com/gu/ami/amiup/AmiUp.scala
@@ -106,7 +106,7 @@ object AmiUp {
 
     cmd("yolo")
       .action((_, c) => c.copy(mode = Yolo))
-      .text("TODO")
+      .text("Run instance refresh on an autoscaling group once the CloudFormation stack is updated")
       .children(
         opt[String]("asg").optional()
           .action { (asg, args) =>

--- a/src/main/scala/com/gu/ami/amiup/AmiUp.scala
+++ b/src/main/scala/com/gu/ami/amiup/AmiUp.scala
@@ -42,7 +42,7 @@ object AmiUp {
         for {
           // find stacks
           matchingStacks <- EitherT.right(
-            UpdateCloudFormation.findStacks(Right(Seq(stackName)), parameterName, cloudFormationClient)
+            UpdateCloudFormation.findStackByName(stackName, cloudFormationClient)
           )
           // validate stacks
           stacks <- EitherT.fromEither[Future](

--- a/src/main/scala/com/gu/ami/amiup/AmiUp.scala
+++ b/src/main/scala/com/gu/ami/amiup/AmiUp.scala
@@ -91,6 +91,7 @@ object AmiUp {
       } action { (region, args) =>
         args.copy(region = Region.of(region))
       } text "AWS region name (defaults to eu-west-1)"
+    help('h', "help").text("Prints this usage text")
     note(
       """
         |Update the AMI parameter of your cloudformation stacks.

--- a/src/main/scala/com/gu/ami/amiup/AmiUp.scala
+++ b/src/main/scala/com/gu/ami/amiup/AmiUp.scala
@@ -59,9 +59,7 @@ object AmiUp {
           )
           // begin rolling update of instances in the ASG
           response <- EitherT.right(AutoScaling.startInstanceRefresh(autoScalingClient, matchingAsg))
-          _ <- EitherT.right(
-            AutoScaling.describeInstanceRefresh(autoScalingClient, matchingAsg , response.instanceRefreshId)
-          )
+          _ <- AutoScaling.pollUntilComplete(autoScalingClient, matchingAsg, response.instanceRefreshId)
         } yield Right(())
       case _ =>
         EitherT[Future, String, Unit](Future.successful(Right(())))

--- a/src/main/scala/com/gu/ami/amiup/aws/AWS.scala
+++ b/src/main/scala/com/gu/ami/amiup/aws/AWS.scala
@@ -11,8 +11,10 @@ import scala.jdk.FutureConverters._
 
 
 object AWS extends LazyLogging {
-  def describeStacks(client: CloudFormationAsyncClient): Future[DescribeStacksResponse] = {
-    val request = DescribeStacksRequest.builder().build()
+  def describeStacks(client: CloudFormationAsyncClient, stackName: Option[String]): Future[DescribeStacksResponse] = {
+    val request = stackName.fold(DescribeStacksRequest.builder().build()) { name =>
+      DescribeStacksRequest.builder().stackName(name).build()
+    }
     client.describeStacks(request).asScala
   }
 

--- a/src/main/scala/com/gu/ami/amiup/aws/AutoScaling.scala
+++ b/src/main/scala/com/gu/ami/amiup/aws/AutoScaling.scala
@@ -45,9 +45,11 @@ object AutoScaling extends LazyLogging {
 
   // If the update process fails, any instances already replaced are not rolled back to their previous configuration.
   // Rolling updates can fail due to failed health checks or if instances are on standby or are protected from scale in.
-  def describeInstanceRefresh(client: AutoScalingAsyncClient, asg: AutoScalingGroup): Future[DescribeInstanceRefreshesResponse] = {
+  def describeInstanceRefresh(client: AutoScalingAsyncClient, asg: AutoScalingGroup, instanceRefreshId: String): Future[DescribeInstanceRefreshesResponse] = {
     val request = DescribeInstanceRefreshesRequest.builder()
-      .autoScalingGroupName(asg.autoScalingGroupName).build()
+      .autoScalingGroupName(asg.autoScalingGroupName)
+      .instanceRefreshIds(instanceRefreshId)
+      .build()
     client.describeInstanceRefreshes(request).asScala
   }
 

--- a/src/main/scala/com/gu/ami/amiup/aws/AutoScaling.scala
+++ b/src/main/scala/com/gu/ami/amiup/aws/AutoScaling.scala
@@ -1,0 +1,66 @@
+package com.gu.ami.amiup.aws
+
+
+import com.typesafe.scalalogging.LazyLogging
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.autoscaling.AutoScalingAsyncClient
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
+import software.amazon.awssdk.services.autoscaling.model._
+
+import scala.concurrent.Future
+import scala.jdk.FutureConverters._
+import scala.jdk.CollectionConverters._
+
+object AutoScaling extends LazyLogging {
+
+  def client(profile: String, region: Region): AutoScalingAsyncClient = {
+    AutoScalingAsyncClient.builder()
+      .credentialsProvider(ProfileCredentialsProvider.builder().profileName(profile).build())
+      .region(region)
+      .build()
+  }
+
+  def describeAutoScalingGroup(client: AutoScalingAsyncClient, asgName: String): Future[DescribeAutoScalingGroupsResponse] = {
+    val request = DescribeAutoScalingGroupsRequest
+      .builder().autoScalingGroupNames(asgName).build()
+    client.describeAutoScalingGroups(request).asScala
+  }
+
+  def parseAutoScalingGroups(asgName: String, response: DescribeAutoScalingGroupsResponse): Either[String, AutoScalingGroup] = {
+    val allAsgs = response.autoScalingGroups.asScala.toSeq
+    val matchingAsgs = allAsgs.filter(asg => asg.autoScalingGroupName.contains(asgName))
+
+    matchingAsgs match {
+      case Nil => Left(s"AutoScaling group $asgName could not be found")
+      case targetAsg :: Nil => Right(targetAsg)
+      case _ => Left(s"Multiple groups found for $asgName, the name should be unique")
+    }
+  }
+
+  def startInstanceRefresh(client: AutoScalingAsyncClient, asg: AutoScalingGroup): Future[StartInstanceRefreshResponse] = {
+    val request = StartInstanceRefreshRequest.builder()
+      .autoScalingGroupName(asg.autoScalingGroupName).build()
+    client.startInstanceRefresh(request).asScala
+  }
+
+  // If the update process fails, any instances already replaced are not rolled back to their previous configuration.
+  // Rolling updates can fail due to failed health checks or if instances are on standby or are protected from scale in.
+  def describeInstanceRefresh(client: AutoScalingAsyncClient, asg: AutoScalingGroup): Future[DescribeInstanceRefreshesResponse] = {
+    val request = DescribeInstanceRefreshesRequest.builder()
+      .autoScalingGroupName(asg.autoScalingGroupName).build()
+    client.describeInstanceRefreshes(request).asScala
+  }
+
+  private[aws] def isFinished(refresh: InstanceRefresh): Boolean = {
+    refresh.status match {
+      case InstanceRefreshStatus.PENDING => false
+      case InstanceRefreshStatus.IN_PROGRESS => false
+      case InstanceRefreshStatus.CANCELLING => false
+      case InstanceRefreshStatus.SUCCESSFUL => true
+      case InstanceRefreshStatus.FAILED => true
+      case InstanceRefreshStatus.CANCELLED => true
+      case _ => false
+    }
+  }
+
+}

--- a/src/main/scala/com/gu/ami/amiup/aws/PollDescribeStackStatus.scala
+++ b/src/main/scala/com/gu/ami/amiup/aws/PollDescribeStackStatus.scala
@@ -45,7 +45,7 @@ object PollDescribeStackStatus extends LazyLogging {
 
   private def getStackStatuses(stacks: Seq[Stack], client: CloudFormationAsyncClient)(implicit ec: ExecutionContext): EitherT[Future, String, Seq[Stack]] = {
     EitherT {
-      AWS.describeStacks(client).map { dsr =>
+      AWS.describeStacks(client, None).map { dsr =>
         logger.debug("Fetched describeStacksResponse")
         Right(dsr.stacks.asScala.toList.filter { stack =>
           stacks.exists(_.stackId == stack.stackId)

--- a/src/main/scala/com/gu/ami/amiup/aws/UpdateCloudFormation.scala
+++ b/src/main/scala/com/gu/ami/amiup/aws/UpdateCloudFormation.scala
@@ -15,9 +15,15 @@ object UpdateCloudFormation extends LazyLogging {
     StackStatus.UPDATE_ROLLBACK_COMPLETE
   )
 
+  def findStackByName(stackName: String, client: CloudFormationAsyncClient): Future[Seq[Stack]] = {
+    for {
+      describeStacksResponse <- AWS.describeStacks(client, Some(stackName))
+    } yield describeStacksResponse.stacks.asScala.toSeq
+  }
+
   def findStacks(existingAmiOrStacks: Either[String, Seq[String]], parameterName: String, client: CloudFormationAsyncClient): Future[Seq[Stack]] = {
     for {
-      describeStacksResponse <- AWS.describeStacks(client)
+      describeStacksResponse <- AWS.describeStacks(client, None)
     } yield {
       val allStacks = describeStacksResponse.stacks.asScala.toSeq
       logger.info(s"Found ${allStacks.size} stacks")

--- a/src/main/scala/com/gu/ami/amiup/aws/UpdateCloudFormation.scala
+++ b/src/main/scala/com/gu/ami/amiup/aws/UpdateCloudFormation.scala
@@ -66,7 +66,10 @@ object UpdateCloudFormation extends LazyLogging {
             .parameterValue(newAmi)
             .build()
         case parameter =>
-          parameter
+          Parameter.builder()
+            .parameterKey(parameter.parameterKey)
+            .usePreviousValue(true)
+            .build()
       }.asJava)
       .build()
 

--- a/src/main/scala/com/gu/ami/amiup/models.scala
+++ b/src/main/scala/com/gu/ami/amiup/models.scala
@@ -1,6 +1,7 @@
 package com.gu.ami.amiup
 
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.autoscaling.model.InstanceRefreshStatus
 import software.amazon.awssdk.services.cloudformation.model.Stack
 
 
@@ -30,4 +31,13 @@ case class StackProgress(
   started: Boolean,
   finished: Boolean,
   failed: Boolean
+)
+
+case class InstanceRefreshProgress(
+  asgName: String,
+  started: Boolean,
+  failed: Boolean,
+  finished: Boolean,
+  status: Option[InstanceRefreshStatus],
+  statusReason: Option[String],
 )

--- a/src/main/scala/com/gu/ami/amiup/models.scala
+++ b/src/main/scala/com/gu/ami/amiup/models.scala
@@ -13,17 +13,17 @@ case object Safe extends AmiupMode
 
 case class Arguments(
   mode: AmiupMode,
-  newAmi: String, // used for both
-  profile: String, // think we need for both?
-  parameterName: String = "AMI", // used for both
-  existingAmi: Option[String] = None, // standard, but maybe discuss removing?
-  stackIds: Option[Seq[String]] = None, // standard
-  stackName: Option[String] = None, // yolo (can we merge with above?)
-  asgName: Option[String] = None, // yolo
-  region: Region = Region.EU_WEST_1  // used for both
+  newAmi: String,
+  profile: String,
+  parameterName: String = "AMI",
+  existingAmi: Option[String] = None,
+  stackIds: Option[Seq[String]] = None,
+  stackName: Option[String] = None,
+  asgName: Option[String] = None,
+  region: Region = Region.EU_WEST_1
 )
 object Arguments {
-  def empty() = Arguments(Safe, "", "")
+  def empty(): Arguments = Arguments(Safe, "", "")
 }
 
 case class StackProgress(

--- a/src/main/scala/com/gu/ami/amiup/models.scala
+++ b/src/main/scala/com/gu/ami/amiup/models.scala
@@ -6,16 +6,23 @@ import software.amazon.awssdk.services.cloudformation.model.Stack
 
 case class AMI(amiId: String)
 
+sealed trait AmiupMode
+case object Yolo extends AmiupMode
+case object Safe extends AmiupMode
+
 case class Arguments(
-  newAmi: String,
-  profile: String,
-  parameterName: String = "AMI",
-  existingAmi: Option[String] = None,
-  stackIds: Option[Seq[String]] = None,
-  region: Region = Region.EU_WEST_1
+  mode: AmiupMode,
+  newAmi: String, // used for both
+  profile: String, // think we need for both?
+  parameterName: String = "AMI", // used for both
+  existingAmi: Option[String] = None, // standard, but maybe discuss removing?
+  stackIds: Option[Seq[String]] = None, // standard
+  stackName: Option[String] = None, // yolo (can we merge with above?)
+  asgName: Option[String] = None, // yolo
+  region: Region = Region.EU_WEST_1  // used for both
 )
 object Arguments {
-  def empty() = Arguments("", "")
+  def empty() = Arguments(Safe, "", "")
 }
 
 case class StackProgress(


### PR DESCRIPTION
## What does this change and what is the value of this?

#### 👉 Add Yolo mode to amiup

As a maintainer of applications running in AWS, I want to improve my workflow for updating an AMI and replacing the instance(s) in an autoscaling group. There are some applications that will encounter issues if more than one instance is running (e.g. Privatebin, Wazuh Coordinator).

During a yolo AMI update the running instance is terminated before a new one is started.

AWS Instance Refresh is a new feature in EC2 Auto Scaling that enables automatic deployments of instances in Auto Scaling Groups), in order to release new application versions or make infrastructure updates.

https://aws.amazon.com/blogs/compute/introducing-instance-refresh-for-ec2-auto-scaling/ 

#### 👉 Fix issue affecting noecho parameters

When performing AMI updates on templates that had parameters with `noecho` set to `true`, the value would change to an empty string. Amiup now uses the previous value for all parameters except for the one relating to the AMI.

#### 👉  Add assembly merge strategy to fix deduplication

Running `./sbt assembly` was not successful due to duplicate AWS SDK configuration files. The [documentation for sbt-assembly](https://github.com/sbt/sbt-assembly#merge-strategy) recommends specifying a merge strategy to resolve deduplication issues.

When running `./sbt assembly` 'discard' is applied to 87 files and 'first' is applied to a single file

## How to test

1) Run the project directly with sbt
2) Attempt to update an AMI

or...

1) Build the jar using the assembly method 
2) Use the jar to attempt to update an AMI

Both methods have been tested on this branch and work as expected ✅ ✅ 


