### PR TITLE
ci: Move to Java 11 Corretto

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,11 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Java 8
-        uses: actions/setup-java@v3
+      - uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '11'
+          distribution: 'corretto'
           cache: 'sbt'
 
       - name: Run tests


### PR DESCRIPTION
## What does this change?
Moves to Java 11 Corretto following [this advice](https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit#):

> The Guardian is recommending teams stop using Java 8 and move to Java 11 Corretto for all applications.

## How to test
CI should pass.