### PR TITLE
docs: Archive the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **Note**
+> This repository is now archieved in favour of [using Riff-Raff to update AMIs in CloudFormation templates](https://riffraff.gutools.co.uk/docs/magenta-lib/types#amicloudformationparameter).
+> If you've got questions on how to do this, please contact the DevX Operations team.
+
 AMIUP
 =====
 


### PR DESCRIPTION
Adds a note to the README to explain why this repository is archived.

This PR should be merged after surveying the department to assess if this tool is no longer in use.